### PR TITLE
Add Daniel Tefera to Backend Team members list.

### DIFF
--- a/Names.md
+++ b/Names.md
@@ -36,6 +36,7 @@ This is a document holds the team members of the different sub teams in the A2SV
 - **Full-Time**
   - Miruts Hadush
   - Henok Adane
+  - Daniel Tefera
   - Kaleab Girma
   - Natnael Awel
   - Selamawit Elias


### PR DESCRIPTION
I added my name under the backed-full timers name list. I assumed the first two names are for the Team Lead and Deputy Lead, so I inserted my name alphabetically afterwards. 